### PR TITLE
fix bug: resourceApiData.propertiesDefinition must not be null

### DIFF
--- a/org.eclipse.winery.ui/src/app/instance/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.ui/src/app/instance/propertiesDefinition/propertiesDefinition.component.ts
@@ -135,10 +135,17 @@ export class PropertiesDefinitionComponent implements OnInit {
                 error => this.handleError(error)
             );
 
+        if (isNullOrUndefined(this.resourceApiData.propertiesDefinition)) {
+            this.resourceApiData.propertiesDefinition = new PropertiesDefinition();
+        }
+        this.resourceApiData.propertiesDefinition.element = null;
+        this.resourceApiData.propertiesDefinition.type = null;
+
+
         if (isNullOrUndefined(this.resourceApiData.winerysPropertiesDefinition)) {
             this.resourceApiData.winerysPropertiesDefinition = new WinerysPropertiesDefinition();
         }
-        // The key/value pair list my be null
+        // The key/value pair list may be null
         if (isNullOrUndefined(this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList)) {
             this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList = [];
         }


### PR DESCRIPTION
`resourceApiData.propertiesDefinition` must not be null when saving custom key/value pairs to the server.
The Object `propertiesDefinition` has to exist/be initialized with its properties set to null.
Otherwise the backend returns an error.


