### PR TITLE
Add tests for adding inheritance for nodetypes and ploicytypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ dist: trusty
 before_install:
   # This is https://github.com/codacy/codacy-coverage-reporter#install-jpm, but the SSL certificate is expired, therefore we directly do the commands of the install script here
   # This is needed, because we use TypeScript and Java in one project
+  # commented because of https://github.com/codacy/codacy-coverage-reporter/issues/46
   # - curl -sL https://github.com/jpm4j/jpm4j.installers/raw/master/dist/biz.aQute.jpm.run.jar >jpm4j.jar
   # - java -jar jpm4j.jar -u init
   # - ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ sudo: required
 dist: trusty
 
 before_install:
-  # This is https://github.com/codacy/codacy-coverage-reporter#install-jpm, but the SSL certificate is expired, therefore we directly do the commands of the install script here
-  # This is needed, because we use TypeScript and Java in one project
-  - curl -sL https://github.com/jpm4j/jpm4j.installers/raw/master/dist/biz.aQute.jpm.run.jar >jpm4j.jar
-  - java -jar jpm4j.jar -u init
-  - ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
+  - wget https://github.com/codacy/codacy-coverage-reporter/releases/download/1.0.13/codacy-coverage-reporter-assembly-1.0.5.jar
 
 script:
   - mvn package --fail-at-end
@@ -22,7 +18,7 @@ script:
 #upload codecov report
 after_script:
   - bash <(curl -s https://codecov.io/bash)
-#  - ~/jpm/bin/codacy-coverage-reporter -l Java -r target/site/jacoco-agregate/jacoco.xml
+  - java -cp codacy-coverage-reporter-assembly-1.0.5.jar com.codacy.CodacyCoverageReporter -l Java -r jacoco.xml
   - echo -n $ID_RSA_TRAVIS_{1..23} >> ~/.ssh/id_rsa_base64
   - if [ -n "$ID_RSA_TRAVIS_1" ]; then scripts/upload-to-builds.opentosca.org.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ sudo: required
 dist: trusty
 
 before_install:
-  - wget https://github.com/codacy/codacy-coverage-reporter/releases/download/1.0.13/codacy-coverage-reporter-assembly-1.0.5.jar
+  # This is https://github.com/codacy/codacy-coverage-reporter#install-jpm, but the SSL certificate is expired, therefore we directly do the commands of the install script here
+  # This is needed, because we use TypeScript and Java in one project
+  # - curl -sL https://github.com/jpm4j/jpm4j.installers/raw/master/dist/biz.aQute.jpm.run.jar >jpm4j.jar
+  # - java -jar jpm4j.jar -u init
+  # - ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
 
 script:
   - mvn package --fail-at-end
@@ -18,7 +22,7 @@ script:
 #upload codecov report
 after_script:
   - bash <(curl -s https://codecov.io/bash)
-  - java -cp codacy-coverage-reporter-assembly-1.0.5.jar com.codacy.CodacyCoverageReporter -l Java -r jacoco.xml
+#  - ~/jpm/bin/codacy-coverage-reporter -l Java -r target/site/jacoco-agregate/jacoco.xml
   - echo -n $ID_RSA_TRAVIS_{1..23} >> ~/.ssh/id_rsa_base64
   - if [ -n "$ID_RSA_TRAVIS_1" ]; then scripts/upload-to-builds.opentosca.org.sh; fi
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/AbstractComponentInstanceResourceWithNameDerivedFromAbstractFinal.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/AbstractComponentInstanceResourceWithNameDerivedFromAbstractFinal.java
@@ -50,10 +50,8 @@ public abstract class AbstractComponentInstanceResourceWithNameDerivedFromAbstra
 	}
 
 	/**
-	 * @return The associated name of this resource. CSDPR01 foresees a NCName
-	 *         name and no ID for an entity type. Therefore, we use the ID as
-	 *         unique identification and convert it to a name when a read
-	 *         request is put.
+	 * @return The associated name of this resource. CSDPR01 foresees a NCName name and no ID for an entity type.
+	 * Therefore, we use the ID as unique identification and convert it to a name when a read request is put.
 	 */
 	@GET
 	@Path("name")
@@ -135,17 +133,19 @@ public abstract class AbstractComponentInstanceResourceWithNameDerivedFromAbstra
 	}
 
 	/**
-	 *
-	 * @param json
 	 * @return Response
 	 */
 	Response putInheritance(InheritanceResourceApiData json) {
-		QName qname = QName.valueOf(json.derivedFrom);
-
 		// see getAvailableSuperClasses for verbose comments
+		DerivedFrom derivedFrom = null;
 		Method method;
-		DerivedFrom derivedFrom = new DerivedFrom();
-		derivedFrom.setTypeRef(qname);
+
+		// If (none) is selected, derivedFrom needs to be null in order to have valid XML in ALL cases!
+		if (!json.derivedFrom.endsWith("(none)")) {
+			QName qname = QName.valueOf(json.derivedFrom);
+			derivedFrom = new DerivedFrom();
+			derivedFrom.setTypeRef(qname);
+		}
 
 		try {
 			method = this.getElement().getClass().getMethod("setDerivedFrom", DerivedFrom.class);
@@ -163,5 +163,4 @@ public abstract class AbstractComponentInstanceResourceWithNameDerivedFromAbstra
 		}
 		return BackendUtils.persist(this);
 	}
-
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/InheritanceResource.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/resources/InheritanceResource.java
@@ -49,8 +49,8 @@ public class InheritanceResource {
 	 *
 	 * @return JSON object in the format
 	 * {
-	 *    "abstract": "no",
-	 *    "final": "yes",
+	 *    "isAbstract": "no",
+	 *    "isFinal": "yes",
 	 *    "derivedFrom": "[QName]"
 	 *  }
 	 */
@@ -63,8 +63,8 @@ public class InheritanceResource {
 	/**
 	 * Saves the inheritance management from a putted json object in the format:
 	 * {
-	 *   "abstract": "no",
-	 *   "final": "yes",
+	 *   "isAbstract": "no",
+	 *   "isFinal": "yes",
 	 *   "derivedFrom": "[QName]"
 	 * }
 	 *

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/InheritanceResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/InheritanceResourceTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v10.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Contributors:
+ * Lukas Harzenetter - initial API and implementation
+ */
+
+package org.eclipse.winery.repository.resources;
+
+import org.junit.Test;
+
+public class InheritanceResourceTest extends AbstractResourceTest {
+
+	@Test
+	public void addInheritanceToNodeType() throws Exception {
+		this.setRevisionTo("2fd9edf31bc0d7a1118fa19eb7050922d0653cb0");
+		this.assertPut("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/inheritance/", "entitytypes/nodetypes/grape_add_inheritance.json");
+		this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/inheritance/", "entitytypes/nodetypes/grape_add_inheritance.json");
+		// Also assure that the XML is still valid
+		this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/", "entitytypes/nodetypes/grape_inheritance.xml");
+	}
+
+	@Test
+	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOneNodeType() throws Exception{
+		this.setRevisionTo("2fd9edf31bc0d7a1118fa19eb7050922d0653cb0");
+		this.assertPut("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/inheritance/", "entitytypes/nodetypes/grape_add_none_inheritance.json");
+		this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/", "entitytypes/nodetypes/grape_inheritance_none.xml");
+	}
+
+	@Test
+	public void addInheritanceToPolicyType() throws Exception {
+		this.setRevisionTo("96a908b37fd3ee190d6371eff4112455eb0097fb");
+		this.assertPut("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/inheritance/", "entitytypes/policytypes/european_add_inheritance.json");
+		this.assertGet("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/inheritance/", "entitytypes/policytypes/european_add_inheritance.json");
+		// Also assure that the XML is still valid
+		this.assertGet("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/", "entitytypes/policytypes/european_inheritance.xml");
+	}
+
+	@Test
+	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOnePolicyType() throws Exception{
+		this.setRevisionTo("96a908b37fd3ee190d6371eff4112455eb0097fb");
+		this.assertPut("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/inheritance/", "entitytypes/policytypes/organic_add_none_inheritance.json");
+		this.assertGet("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/", "entitytypes/policytypes/organic_inheritance_none.xml");
+	}
+}

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/InheritanceResourceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/resources/InheritanceResourceTest.java
@@ -26,7 +26,7 @@ public class InheritanceResourceTest extends AbstractResourceTest {
 	}
 
 	@Test
-	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOneNodeType() throws Exception{
+	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOneNodeType() throws Exception {
 		this.setRevisionTo("2fd9edf31bc0d7a1118fa19eb7050922d0653cb0");
 		this.assertPut("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/inheritance/", "entitytypes/nodetypes/grape_add_none_inheritance.json");
 		this.assertGet("nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/", "entitytypes/nodetypes/grape_inheritance_none.xml");
@@ -42,7 +42,7 @@ public class InheritanceResourceTest extends AbstractResourceTest {
 	}
 
 	@Test
-	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOnePolicyType() throws Exception{
+	public void xmlStillValidAfterAddingDerivedFromNoneInheritanceToOnePolicyType() throws Exception {
 		this.setRevisionTo("96a908b37fd3ee190d6371eff4112455eb0097fb");
 		this.assertPut("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/inheritance/", "entitytypes/policytypes/organic_add_none_inheritance.json");
 		this.assertGet("policytypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fpolicytypes%252Ffruits/european/", "entitytypes/policytypes/organic_inheritance_none.xml");

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_add_inheritance.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_add_inheritance.json
@@ -1,0 +1,5 @@
+{
+  "isAbstract": "no",
+  "isFinal": "yes",
+  "derivedFrom": "{http://winery.opentosca.org/test/nodetypes/fruits}baobab"
+}

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_add_none_inheritance.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_add_none_inheritance.json
@@ -1,0 +1,5 @@
+{
+  "isAbstract": "yes",
+  "isFinal": "no",
+  "derivedFrom": "(none)"
+}

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_inheritance.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_inheritance.xml
@@ -1,0 +1,30 @@
+<tosca:Definitions xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="winery-defs-for_wfn-grape" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits">
+	<tosca:Import importType="http://docs.oasis-open.org/tosca/ns/2011/12" location="wfn__baobab.tosca" namespace="http://winery.opentosca.org/test/nodetypes/fruits"/>
+	<tosca:Import importType="http://www.w3.org/2001/XMLSchema" location="../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/propertiesdefinition/GrapeProperties.xsd" namespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:wpd="true"/>
+	<tosca:NodeType abstract="no" final="yes" name="grape" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
+		<winery:PropertiesDefinition elementname="GrapeProperties" namespace="http://winery.opentosca.org/test/nodetypes/fruits">
+			<winery:properties>
+				<winery:key>Antioxidants</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>VitaminC</winery:key>
+				<winery:type>xsd:decimal</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>Potassium</winery:key>
+				<winery:type>xsd:float</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>Superfood</winery:key>
+				<winery:type>xsd:boolean</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>HarvestedAt</winery:key>
+				<winery:type>xsd:anyURI</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<tosca:DerivedFrom xmlns:wfn="http://winery.opentosca.org/test/nodetypes/fruits" typeRef="wfn:baobab"/>
+		<tosca:PropertiesDefinition xmlns:wfn="http://winery.opentosca.org/test/nodetypes/fruits" type="wfn:GrapeProperties"/>
+	</tosca:NodeType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_inheritance_none.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/nodetypes/grape_inheritance_none.xml
@@ -1,0 +1,28 @@
+<tosca:Definitions xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" id="winery-defs-for_wfn-grape" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits">
+	<tosca:Import importType="http://www.w3.org/2001/XMLSchema" location="../nodetypes/http%253A%252F%252Fwinery.opentosca.org%252Ftest%252Fnodetypes%252Ffruits/grape/propertiesdefinition/GrapeProperties.xsd" namespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:wpd="true"/>
+	<tosca:NodeType abstract="yes" final="no" name="grape" targetNamespace="http://winery.opentosca.org/test/nodetypes/fruits" winery:bordercolor="#89ee01">
+		<winery:PropertiesDefinition elementname="GrapeProperties" namespace="http://winery.opentosca.org/test/nodetypes/fruits">
+			<winery:properties>
+				<winery:key>Antioxidants</winery:key>
+				<winery:type>xsd:string</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>VitaminC</winery:key>
+				<winery:type>xsd:decimal</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>Potassium</winery:key>
+				<winery:type>xsd:float</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>Superfood</winery:key>
+				<winery:type>xsd:boolean</winery:type>
+			</winery:properties>
+			<winery:properties>
+				<winery:key>HarvestedAt</winery:key>
+				<winery:type>xsd:anyURI</winery:type>
+			</winery:properties>
+		</winery:PropertiesDefinition>
+		<tosca:PropertiesDefinition xmlns:wfn="http://winery.opentosca.org/test/nodetypes/fruits" type="wfn:GrapeProperties"/>
+	</tosca:NodeType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/european_add_inheritance.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/european_add_inheritance.json
@@ -1,0 +1,5 @@
+{
+  "isAbstract": "no",
+  "isFinal": "yes",
+  "derivedFrom": "{http://winery.opentosca.org/test/policytypes/fruits}organic"
+}

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/european_inheritance.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/european_inheritance.xml
@@ -1,0 +1,6 @@
+<tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_wfp-european" targetNamespace="http://winery.opentosca.org/test/policytypes/fruits">
+	<tosca:Import namespace="http://winery.opentosca.org/test/policytypes/fruits" location="wfp__organic.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+	<tosca:PolicyType name="european" abstract="no" final="yes" targetNamespace="http://winery.opentosca.org/test/policytypes/fruits">
+		<tosca:DerivedFrom xmlns:wfp="http://winery.opentosca.org/test/policytypes/fruits" typeRef="wfp:organic"/>
+	</tosca:PolicyType>
+</tosca:Definitions>

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/organic_add_none_inheritance.json
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/organic_add_none_inheritance.json
@@ -1,0 +1,5 @@
+{
+  "isAbstract": "no",
+  "isFinal": "yes",
+  "derivedFrom": "(none)"
+}

--- a/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/organic_inheritance_none.xml
+++ b/org.eclipse.winery.repository/src/test/resources/entitytypes/policytypes/organic_inheritance_none.xml
@@ -1,0 +1,3 @@
+<tosca:Definitions xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:selfservice="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_wfp-european" targetNamespace="http://winery.opentosca.org/test/policytypes/fruits">
+	<tosca:PolicyType name="european" abstract="no" final="yes" targetNamespace="http://winery.opentosca.org/test/policytypes/fruits"/>
+</tosca:Definitions>

--- a/org.eclipse.winery.ui/src/app/section/section.component.ts
+++ b/org.eclipse.winery.ui/src/app/section/section.component.ts
@@ -43,7 +43,7 @@ export class SectionComponent implements OnInit, OnDestroy {
     showNamespace = 'all';
     changeViewButtonTitle: string = showGrouped;
     componentData: SectionData[];
-    types: SelectData;
+    types: SelectData[];
 
     newComponentName: string;
     newComponentNamespace: string;
@@ -180,13 +180,6 @@ export class SectionComponent implements OnInit, OnDestroy {
                         error => this.handleError(error)
                     );
                 break;
-            case 'policyType':
-                this.service.getSectionData('/policytypes?grouped=angularSelect')
-                    .subscribe(
-                        data => this.handleTypes(data),
-                        error => this.handleError(error)
-                    );
-                break;
             case 'policyTemplate':
                 this.service.getSectionData('/policytemplates?grouped=angularSelect')
                     .subscribe(
@@ -199,9 +192,9 @@ export class SectionComponent implements OnInit, OnDestroy {
         }
     }
 
-    private handleTypes(types: SelectData): void {
+    private handleTypes(types: SelectData[]): void {
         this.loading = false;
-        this.types = types;
+        this.types = types.length > 0 ? types : null;
     }
 
     private handleSaveSuccess() {


### PR DESCRIPTION
If a inheritance is added to a policytype and derivedFrom is set to `(none)` the xml is not valid anymore. However, it strangely works for nodetypes. Therefore, I now ensure that, if derivedFrom is set to (none), derived from is set correctly.

I also added some test for this.